### PR TITLE
Store start rounded

### DIFF
--- a/float_range/range.py
+++ b/float_range/range.py
@@ -24,8 +24,9 @@ class FloatRange:
         if self._is_empty():
             raise StopIteration
 
-        res = round(self.start, self.precision)
-        self.start += self.step
+        res = self.start
+        self.start = round(self.start + self.step, self.precision)
+
         return res
 
     def next(self):

--- a/tests/test_range.py
+++ b/tests/test_range.py
@@ -227,6 +227,12 @@ class TestRange(unittest.TestCase):
 
         self.assertEqual(expected_value, given_value)
 
+    def test_properly_sum_floats(self):
+        expected_value = [9, 9.2, 9.4, 9.6, 9.8]
+        given_value = [i for i in float_range.range(9, 10, 0.2)]
+
+        self.assertEqual(expected_value, given_value)
+
 
 class TestPrecision(unittest.TestCase):
 


### PR DESCRIPTION
We were rounding the results only to return (show the user). This led to
the float rounding issue. We were showing results that made sense but,
since our internal state was not rounded, some cases it'd bite us.

For example, when going from `9` to `10` with a `0.2` step we should
get:
```python
    >>> [9, 9.2, 9.4, 9.6, 9.8]
```
but were instead getting
```python
    >>> [9, 9.2, 9.4, 9.6, 9.8, 10.0]
```
That's because:
```python
    >>> i = 9
    >>> while i < 10:
    ...     print(i)
    ...     i += 0.2
    ...
    9
    9.2
    9.399999999999999
    9.599999999999998
    9.799999999999997
    9.999999999999996
```
We were storing `start` with the above values but were displaying the
rounded one:
```python
    >>> i = 9
    >>> while i < 10:
    ...     print(round(i, 1))
    ...     i += 0.2
    ...
    9
    9.2
    9.4
    9.6
    9.8
    10.0
```
If we use the rounded values instead, the issue is fixed:
```python
    >>> i = 9
    >>> while i < 10:
    ...     print(i)
    ...     i = round(i + 0.2, 1)
    ...
    9
    9.2
    9.4
    9.6
    9.8
```
These examples were just a simplification of what goes on in `FloatRange`,
but the principle is the same and is what is introduced by this PR.