### PR TITLE
Reset sequence when __iter__ is called

### DIFF
--- a/float_range/range.py
+++ b/float_range/range.py
@@ -12,12 +12,16 @@ class FloatRange:
             self.start = start
             self.stop = stop
 
+        self.initial_start = self.start
+        self.initial_stop = self.stop
+
         self.minor = min(self.start, self.stop)
         self.major = max(self.start, self.stop)
         self.step = step
         self.precision = FloatRange._precision(step)
 
     def __iter__(self):
+        self._reset()
         return self
 
     def __next__(self):
@@ -119,6 +123,10 @@ class FloatRange:
 
     def _is_decreasing(self):
         return self.start <= self.stop and self.step < 0
+
+    def _reset(self):
+        self.start = self.initial_start
+        self.stop = self.initial_stop
 
 
 def range(start, stop=None, step=1):

--- a/tests/test_range.py
+++ b/tests/test_range.py
@@ -50,14 +50,14 @@ class TestFloatRange(unittest.TestCase):
         given_value = max(FloatRange(10, 0, -1.5))
         self.assertEqual(expected_value, given_value)
 
-#    def test_min_max(self):
-#        seq = FloatRange(10, 0, -1.5)
-#        # previous calls of min and max should not affect now
-#        min(seq)
-#        max(seq)
-#        given_value = min(seq)
-#        expected_value = 1
-#        self.assertEqual(expected_value, given_value)
+    def test_min_max(self):
+       seq = FloatRange(10, 0, -1.5)
+       # previous calls of min and max should not affect now
+       min(seq)
+       max(seq)
+       given_value = min(seq)
+       expected_value = 1
+       self.assertEqual(expected_value, given_value)
 
     def test_contains_true(self):
         expected_value = True


### PR DESCRIPTION
As described in https://github.com/nathan-cruz77/float_range/issues/15, calls to `min` and `max` were iterating over the whole object and rendering it unusable. This behavior is not ideal, and not what we observe in `range`. 

This PR fixes it by resetting the object to its initial state every time a call to `__iter__` is made. It doesn't interfere with other use cases.