### PR TITLE
Remove package install step to speedup tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,8 @@
 init:
 	pip install -e .
 
-test: init
-	python tests/test_*
-	rm -rf float_range.egg-info
+test:
+	python tests/*.py
 
 readme:
 	pandoc --output=README --to rst README.md


### PR DESCRIPTION
It turns out we don't need to install the package locally to run the tests. This makes the tests significantly faster.